### PR TITLE
Add a exception for deleted aws secrets manager

### DIFF
--- a/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
+++ b/spring-cloud-config-server/src/main/java/org/springframework/cloud/config/server/environment/AwsSecretsManagerEnvironmentRepository.java
@@ -21,14 +21,15 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import com.amazonaws.services.secretsmanager.model.InvalidRequestException;
+import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
-import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
-import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
 
 import org.springframework.cloud.config.environment.Environment;
 import org.springframework.cloud.config.environment.PropertySource;
@@ -48,7 +49,7 @@ public class AwsSecretsManagerEnvironmentRepository implements EnvironmentReposi
 
 	private final ObjectMapper objectMapper;
 
-	private final SecretsManagerClient awsSmClient;
+	private final AWSSecretsManager awsSmClient;
 
 	private final ConfigServerProperties configServerProperties;
 
@@ -56,7 +57,7 @@ public class AwsSecretsManagerEnvironmentRepository implements EnvironmentReposi
 
 	private final int order;
 
-	public AwsSecretsManagerEnvironmentRepository(SecretsManagerClient awsSmClient,
+	public AwsSecretsManagerEnvironmentRepository(AWSSecretsManager awsSmClient,
 			ConfigServerProperties configServerProperties,
 			AwsSecretsManagerEnvironmentProperties environmentProperties) {
 		this.awsSmClient = awsSmClient;
@@ -135,12 +136,12 @@ public class AwsSecretsManagerEnvironmentRepository implements EnvironmentReposi
 	private Map<Object, Object> findProperties(String path) {
 		Map<Object, Object> properties = new HashMap<>();
 
-		GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).build();
+		GetSecretValueRequest request = new GetSecretValueRequest().withSecretId(path);
 		try {
-			GetSecretValueResponse response = awsSmClient.getSecretValue(request);
+			GetSecretValueResult response = awsSmClient.getSecretValue(request);
 
 			if (response != null) {
-				Map<String, Object> secretMap = objectMapper.readValue(response.secretString(),
+				Map<String, Object> secretMap = objectMapper.readValue(response.getSecretString(),
 						new TypeReference<Map<String, Object>>() {
 						});
 
@@ -149,7 +150,7 @@ public class AwsSecretsManagerEnvironmentRepository implements EnvironmentReposi
 				}
 			}
 		}
-		catch (ResourceNotFoundException | IOException e) {
+		catch (ResourceNotFoundException | InvalidRequestException | IOException e) {
 			log.debug(String.format(
 					"Skip adding propertySource. Unable to load secrets from AWS Secrets Manager for secretId=%s",
 					path), e);


### PR DESCRIPTION
If aws client requests a secret group in `aws secrets manager` is waiting for a deletion, it returns 400 code with `InvalidRequestException`.

However, the code is only treating `ResourceNotFoundException` as known one.

So, I just added `InvalidRequestException` in the code.

<img width="1187" alt="Screen Shot 2022-07-23 at 13 31 18" src="https://user-images.githubusercontent.com/3631891/180590490-112d7338-3a33-4bd4-9ada-09aa28de7439.png">
<img width="1043" alt="Screen Shot 2022-07-23 at 13 34 49" src="https://user-images.githubusercontent.com/3631891/180590501-fe3046a1-49fe-4870-b5f2-ddf0691758aa.png">